### PR TITLE
(#1204) Fix lib directory permissions

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -43,7 +43,7 @@ class elasticsearch::config {
         ensure  => 'directory',
         group   => '0',
         owner   => 'root',
-        mode    => '0755',
+        mode    => '0644',
         recurse => true;
     }
     if $elasticsearch::manage_datadir {


### PR DESCRIPTION
This module changes the file mode of files in /usr/share/elasticsearch/lib everytime Elasticsearch is upgraded with Apt. This is unnecessary and undesirable.

From this commit https://github.com/voxpupuli/puppet-elasticsearch/commit/854d9022b45e49c00f8b6f7e709a1f1b4372a005, the intention was to fix the permission on the directory, but it is now changing the file mode of all the files in the directory as well.

From tests it is alright to set the file mode on the directory to 0644 as Puppet does the right thing setting the directory mode to 0755, irrespective of the umask value, while setting the file mode to 0644 as expected.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
